### PR TITLE
Remove default values for php and js options

### DIFF
--- a/src/CreateExtensionCommand.php
+++ b/src/CreateExtensionCommand.php
@@ -63,17 +63,15 @@ class CreateExtensionCommand extends MWStewBaseCommand {
 			)
 			->addOption(
 				'js',
-				'js',
-				InputOption::VALUE_OPTIONAL,
-				'Add files for a JavaScript development environment',
-				false
+				null,
+				InputOption::VALUE_NONE,
+				'Add files for a JavaScript development environment'
 			)
 			->addOption(
 				'php',
-				'php',
-				InputOption::VALUE_OPTIONAL,
-				'Add files for a PHP development environment',
-				false
+				null,
+				InputOption::VALUE_NONE,
+				'Add files for a PHP development environment'
 			)
 			->addOption(
 				'specialname',


### PR DESCRIPTION
This removes the default (empty) values for the --php and --js
options, as well as their short names (which weren't working
anyway as they were more than one character), so that these
options can be used in any position in the command string.