### PR TITLE
Add clone-extension command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-php: 7.2
+php: "7.2"
 
 before_install:
   - composer install
@@ -11,8 +11,7 @@ before_script:
 
 script:
   - composer validate
-  - phpunit --coverage-clover ./build/logs/phpunit_clover.xml --configuration tests/phpunit.xml
-  - ./vendor/bin/minus-x check .
+  - composer test
 
 # after_script:
 # - php vendor/bin/coveralls -v

--- a/bin/mwstew
+++ b/bin/mwstew
@@ -28,6 +28,7 @@ $application = new Symfony\Component\Console\Application;
 // Add commands
 $application->add( new MWStew\CLI\CreateExtensionCommand() );
 $application->add( new MWStew\CLI\ListHooksCommand() );
+$application->add( new MWStew\CLI\CloneExtensionCommand() );
 
 // Run the application
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
   },
   "require": {
     "mooeypoo/mwstew-builder": "^1.1",
-    "symfony/console": "^4.2"
+    "symfony/console": "^4.2",
+    "symfony/process": "^4.2"
   },
   "require-dev": {
     "mediawiki/minus-x": "^0.3",

--- a/src/CloneExtensionCommand.php
+++ b/src/CloneExtensionCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace MWStew\CLI;
+
+use function Couchbase\defaultDecoder;
+use Exception;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Process;
+
+class CloneExtensionCommand extends MWStewBaseCommand
+{
+
+	protected function configure()
+	{
+		$this->setName('clone-extension');
+		$this->setDescription("Clone an extension's Git repository. Only supports Gerrit repos at the moment.");
+		$this->addArgument(
+			'name',
+			InputArgument::REQUIRED,
+			'Name of the extension. Alphabet or numbers only, no spaces.'
+		);
+		$this->addOption(
+			'path',
+			'p',
+			InputOption::VALUE_REQUIRED,
+			'The path for the new files.',
+			$this->getExtensionsDir()
+		);
+		$this->addOption(
+			'user',
+			'u',
+			InputOption::VALUE_REQUIRED,
+			'Your Gerrit username.'
+		);
+		$this->addOption(
+			'githook',
+			'g',
+			InputOption::VALUE_NONE,
+			'Whether to add the Gerrit commit-msg hook. Requires --user.'
+		);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output)
+	{
+		parent::execute($input, $output);
+		$io = new SymfonyStyle($input, $output);
+		$path = $input->getOption('path');
+		$name = $input->getArgument('name');
+
+		// Figure out the Git repository URL.
+		$repoUrl = "https://gerrit.wikimedia.org/r/mediawiki/extensions/$name";
+		$user = $input->getOption('user');
+		if ($user) {
+			$repoUrl = "ssh://$user@gerrit.wikimedia.org:29418/mediawiki/extensions/$name";
+		}
+
+		// Run the Git command.
+		$command = ['git', 'clone', '--origin', 'gerrit', $repoUrl, "$path/$name"];
+		$process = new Process($command);
+		$process->mustRun();
+		$io->success("$name has been cloned to $path/$name");
+
+		// See if we should copy the Git hook as well.
+		$useHook = $input->getOption('githook');
+		if ($useHook && !$user) {
+			$io->error('The --githook option can only be used in conjunction with the --user option.');
+			return 1;
+		}
+		if ($useHook) {
+			$command = [
+				'scp',
+				'-p',
+				'-P',
+				'29418',
+				"$user@gerrit.wikimedia.org:hooks/commit-msg",
+				"$path/$name/.git/hooks/"
+			];
+			$process = new Process($command);
+			$process->mustRun();
+			$io->success("The Gerrit commit-msg hook has been installed.");
+		}
+	}
+}

--- a/src/CreateExtensionCommand.php
+++ b/src/CreateExtensionCommand.php
@@ -12,15 +12,6 @@ use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 class CreateExtensionCommand extends MWStewBaseCommand {
 
 	protected function configure() {
-		// The default path assumes we're at the top level of MediaWiki.
-		$defaultPath = getcwd() . '/extensions';
-		if ('extensions' === basename(getcwd())) {
-			// We're in the extensions directory.
-			$defaultPath = getcwd();
-		} elseif ('extensions' === basename(dirname(getcwd()))) {
-			// There's an extensions directory one level up from here (i.e. we're in another extension's directory).
-			$defaultPath = dirname(getcwd());
-		}
 		$this
 			->setName( 'create-extension' )
 			->setDescription( 'Create the basic files needed to develop a new MediaWiki extension' )
@@ -34,7 +25,7 @@ class CreateExtensionCommand extends MWStewBaseCommand {
 				'p',
 				InputOption::VALUE_REQUIRED,
 				'The path for the new files.',
-				$defaultPath
+				$this->getExtensionsDir()
 			)
 			->addOption(
 				'author',


### PR DESCRIPTION
Add a new command with which to clone an extension, optionally
with a username in the clone URL and copying in the Gerrit
commit hook.

Moves and extends the extension-directory finding code to the
base command class so that any command can use it. Adds
additional checks for the directory all the way up the file tree
and to the side at each level (e.g. it's possible to clone into
the extensions directory when you're somewhere down in includes).